### PR TITLE
Upgrade mocha to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-watch": "^4.3.11",
     "istanbul": "^0.4.5",
     "jsdoc-babel": "^0.2.1",
-    "mocha": "^3.1.2",
+    "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.12.1"
   },
   "dependencies": {


### PR DESCRIPTION
Release notes [here](https://github.com/mochajs/mocha/releases/tag/v3.2.0)

If/when we make this project public, we might want to look into [Greenkeeper](https://greenkeeper.io/) so that we don't have to do this manually all the time.