### PR TITLE
Include Docs.md in the JSDoc

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -37,10 +37,19 @@ gulp.task('test', ['build'], () => {
 });
 
 gulp.task('doc', (cb) => {
+    var commander = require('commander');
     var jsdoc = require('gulp-jsdoc3');
     var jsdocConfig = require('./jsdoc.json');
 
-    gulp.src(_.union(['README.md'], sourceFiles), { read: false })
+    commander
+        .option('-p, --private', 'Include private API documentation')
+        .parse(process.argv);
+
+    if (commander.private) {
+        jsdocConfig.opts.private = true;
+    }
+
+    gulp.src(_.union(['Docs.md'], sourceFiles), { read: false })
         .pipe(jsdoc(jsdocConfig, cb));
 });
 

--- a/index.js
+++ b/index.js
@@ -353,6 +353,8 @@ let Fixtures = {
      * Stores the login response.
      *
      * @param {Object} auth The login response.
+     *
+     * @private
      */
     _storeAuth(auth) {
         this._headers['OAuth-Token'] = auth.body.access_token;


### PR DESCRIPTION
This makes for nicer-rendered docs.

Also adds a flag to support private members (disabled by default).