### PR TITLE
gulpfile.babel.js: Fix doc command

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -49,7 +49,7 @@ gulp.task('doc', (cb) => {
         jsdocConfig.opts.private = true;
     }
 
-    return gulp.src(_.union(['Docs.md'], sourceFiles), { read: false })
+    gulp.src(_.union(['Docs.md'], sourceFiles), { read: false })
         .pipe(jsdoc(jsdocConfig, cb));
 });
 


### PR DESCRIPTION
Corrects a mistake from #26 