### PR TITLE
Change the data structure of cachedAgents.

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -500,9 +500,11 @@ describe('Agent', () => {
 
         it('should return a clone of the original agent with updated version', () => {
             let myAgentV11 = myAgent.on('v11');
-
             expect(myAgentV11.version).to.equal('v11');
             expect(myAgentV11).to.not.equal(myAgent);
+
+            let myOtherAgentV11 = myAgent.on('v11');
+            expect(myOtherAgentV11).to.equal(myAgentV11);
         });
     });
 


### PR DESCRIPTION
Specifically, cachedAgents[this.username] now stores a data structure
consisting of a v10 user agent and/or a v11 user agent, plus shared
state. The shared state is used predominantly for session details, as
it ensures that a refresh against a v10 user will also affect the v11
user.

This also fixes a nasty bug where using Agent.on() multiple times would
clone repeatedly, using lots and lots of memory.