### PR TITLE
Switched thorn test to use chakram.expect

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -22,7 +22,7 @@ function isPromise(input) {
 let thorn;
 let Fixtures;
 let Agent;
-let expect;
+let expect = require('chakram').expect;
 let thornFile = '../dist/index.js';
 
 function isTokenReq(url) {
@@ -44,7 +44,6 @@ beforeEach(() => {
     thorn = require(thornFile);
     Agent = thorn.Agent;
     Fixtures = thorn.Fixtures;
-    expect = thorn.Expect;
 });
 
 afterEach(() => {


### PR DESCRIPTION
It didn't seem right to me to use `thorn.Expect` to test the expectations on other thorn methods. This way, in the future, if we do want to wrap `thorn.Expect` in something else, it won't affect the rest of the tests.