### PR TITLE
Upgrade babel-eslint to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "babel-core": "^6.18.2",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.1.1",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2017": "^6.16.0",


### PR DESCRIPTION
I very quickly tested it and it seemed fine to me.

See https://github.com/babel/babel-eslint/releases/tag/v7.0.0 (the major release bump) which doesn't show anything too dangerous. Most notably, it drops support for Node.js 4.x, but we're already enforcing 6.x and above anyways.