### PR TITLE
gulpfile.babel.js: return the stream from the build task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,7 +5,7 @@ var sourceFiles = ['index.js', 'metadata-handler.js'];
 
 gulp.task('build', () => {
     var babel = require('gulp-babel');
-    gulp.src(sourceFiles)
+    return gulp.src(sourceFiles)
         .pipe(babel())
         .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
@khigakisugar, I think this will probably fix the problem with `gulp test` sometimes executing before `gulp build` finishes.