### PR TITLE
Implement bulk expansion for verbose mode

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -398,10 +398,13 @@ order for server requests to effectuate. Not returning `Promises` could lead to 
 
 ## Debugging Tests
 
-While developing or debugging a test, you can set the environment variable `THORN_VERBOSE` to any value to enable
+While developing or debugging a test, you can set the environment variable `THORN_VERBOSE` to enable
 verbose output from Thorn.
 
-Before commiting tests, **please ensure you run them with THORN_VERBOSE enabled** so you can be sure you are making the
+Users of Thorn seeking to debug their tests should set `THORN_VERBOSE=1`.
+`THORN_VERBOSE=2` is intended for those developing Thorn itself and is not intended for users.
+
+Before commiting tests, **please ensure you run them with THORN_VERBOSE=1** so you can be sure you are making the
 HTTP requests and getting the responses back that you expect.
 
 [chakram]: http://dareid.github.io/chakram/

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,63 @@
+let _ = require('lodash');
+
+let bulkDataCache = {};
+
+const VERBOSE_FUNCTIONS = [
+    (type, data, r) => {
+        switch(type) {
+        case 'request':
+            console.info('Request  ' + data.debugId + ' ' + r.headers['X-Thorn'] + ': ' + r.method + ' ' + r.uri.pathname);
+            break;
+        case 'response':
+            console.info('Response ' + data.debugId + ' ' + r.headers['X-Thorn'] + ': ' + r.method + ' ' + r.uri.pathname + ' ' + data.statusCode);
+            break;
+        case 'redirect':
+        case 'auth':
+            console.info('Redirect: ' + data.statusCode + ' ' + data.uri);
+            break;
+        default:
+            console.info('Unidentified event ' + type);
+            break;
+        }
+    },
+    (type, data, r) => {
+        let requests, responses;
+        if (r.method === 'POST' && r.uri.pathname.indexOf('bulk') >= 0) {
+            switch(type) {
+            case 'request':
+                // cache the method and URL of each part of the bulk request,
+                // because the response doesn't disclose that information
+                bulkDataCache[data.debugId] = [];
+                requests = JSON.parse(data.body).requests;
+                _.each(requests, (req, index) => {
+                    bulkDataCache[data.debugId].push({ method: req.method, url: req.url });
+                    console.info('\tBulk Request ' + (index + 1) + ': ' + req.method + ' ' + req.url);
+                });
+                break;
+            case 'response':
+                if (!data.body) {
+                    console.warn('\tBulk Response: no body');
+                    break;
+                }
+                responses = data.body;
+                if (typeof responses === 'string') {
+                    responses = JSON.parse(responses);
+                }
+                if (!_.isArray(responses)) {
+                    responses = [responses];
+                }
+                _.each(responses, (resp, index) => {
+                    let req = bulkDataCache[data.debugId][index];
+                    let msg = '\tBulk Response ' + (index + 1) + ': ' + req.method + ' ' + req.url + ' ' +  resp.status;
+                    console.info(msg);
+                });
+                delete bulkDataCache[data.debugId];
+                break;
+            default:
+                break;
+            }
+        }
+    }
+];
+
+export { VERBOSE_FUNCTIONS };

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var gulp = require('gulp');
 
-var sourceFiles = ['index.js', 'metadata-handler.js', 'utils.js', 'metadata-fetcher.js'];
+var sourceFiles = ['debug.js', 'index.js', 'metadata-handler.js', 'utils.js', 'metadata-fetcher.js'];
 
 gulp.task('build', () => {
     var babel = require('gulp-babel');

--- a/index.js
+++ b/index.js
@@ -11,22 +11,12 @@ let _ = require('lodash');
 let utils = require('./utils.js');
 
 // Verbose mode support for debugging tests
-if (process.env.THORN_VERBOSE) {
+let verbosity = Number.parseInt(process.env.THORN_VERBOSE);
+if (verbosity) {
+    const VERBOSE_FUNCTIONS = require('./debug.js').VERBOSE_FUNCTIONS;
     chakram.startDebug((type, data, r) => {
-        switch(type) {
-        case 'request':
-            console.info('Request  ' + data.debugId + ' ' + r.headers['X-Thorn'] + ': ' + r.method + ' ' + r.uri.pathname);
-            break;
-        case 'response':
-            console.info('Response ' + data.debugId + ' ' + r.headers['X-Thorn'] + ': ' + r.method + ' ' + r.uri.pathname + ' ' + data.statusCode);
-            break;
-        case 'redirect':
-        case 'auth':
-            console.info('Redirect: ' + data.statusCode + ' ' + data.uri);
-            break;
-        default:
-            console.info('Unidentified event ' + type);
-            break;
+        for (let i = 0; i < verbosity; i++) {
+            VERBOSE_FUNCTIONS[i](type, data, r);
         }
     });
 }


### PR DESCRIPTION
By setting `THORN_VERBOSE=2`, you can now see expanded bulk requests and responses.