### PR TITLE
Upgrade lodash to 4.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chakram": "^1.5.0",
-    "lodash": "^4.17.2"
+    "lodash": "^4.17.3"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
Nothing interesting to us. Tests all pass

https://github.com/lodash/lodash/wiki/Changelog#v4173

>
* Added support for symbol properties to _.isEqual
* Avoided coercing position in _.startsWith when it’s undefined
* Ensured getSymbols helper only gets enumerable symbols
* Flipped iteratee arguments for fp.reduceRight
* Removed the array length limit for lazy evaluation