### PR TITLE
Treat .babelrc the same as the other JSON files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "presets": ["es2017", "es2015"],
-    "plugins": ["transform-class-properties"]
+  "presets": ["es2017", "es2015"],
+  "plugins": ["transform-class-properties"]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.json]
+[{*.json,.babelrc}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
i.e. use 2 spaces for it.