### PR TITLE
Fix crash in utils.wrap401 when retrying fixture linking

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,8 +422,12 @@ let Fixtures = {
         return utils.wrap401(
             chakram.post,
             [url, linkDef, params],
-            this._refreshToken,
-            _.bind(this._afterRefresh, this)
+            {
+                afterRefresh: _.bind(this._afterRefresh, this),
+                refreshToken: this._refreshToken,
+                retryVersion: VERSION,
+                xthorn: 'Fixtures'
+            }
         ).then((response) => {
             return response.response.body;
         });

--- a/utils.js
+++ b/utils.js
@@ -88,6 +88,7 @@ var utils = {
      *   a refresh occurs. Passed the chakram response object from the refresh.
      * @param {string} options.retryVersion API version to make the retry request on.
      *   Non-retry requests are made on whatever version is specified by `args`.
+     * @param {string} options.xthorn Value of the X-Thorn header.
      * @return {ChakramPromise} A promise resolving to the result of the request.
      *   If the first try failed, it will resolve to the result of the second,
      *   whether it succeeded or not.


### PR DESCRIPTION
This appears to be a result of me not fixing one of the function calls when I moved some of the code out to utils.js in #56.

I fixed some incomplete documentation related to the function call in question at the same time.