### PR TITLE
metadata-fetcher.js: Remove hardcoded /rest (blocked by #77)

### DIFF
--- a/metadata-fetcher.js
+++ b/metadata-fetcher.js
@@ -38,7 +38,7 @@ var MetadataFetcher = {
             .then((response) => {
                 authToken = response.access_token;
 
-                let url = process.env.API_URL + '/rest/' + VERSION + '/metadata?modules';
+                let url = utils.constructUrl(VERSION, 'metadata') + '?modules';
                 let metadataOptions = {
                     headers: {
                         'X-Thorn': 'MetadataFetcher',


### PR DESCRIPTION
This would cause a double /rest in the metadata fetcher's GET requests