### PR TITLE
Rename env vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function _insertCredentials(username, userhash) {
 function _restore() {
     cachedRecords = {};
     credentials = {
-        [process.env.ADMIN_USERNAME]: process.env.ADMIN_PASSWORD,
+        [process.env.THORN_ADMIN_USERNAME]: process.env.THORN_ADMIN_PASSWORD,
     };
 }
 
@@ -458,8 +458,8 @@ let Fixtures = {
      */
     _adminLogin() {
         return utils.login({
-            username: process.env.ADMIN_USERNAME,
-            password: process.env.ADMIN_PASSWORD,
+            username: process.env.THORN_ADMIN_USERNAME,
+            password: process.env.THORN_ADMIN_PASSWORD,
             version: VERSION,
             xthorn: 'Fixtures',
         }).then((response) => {
@@ -522,7 +522,7 @@ var Agent = {
         return agent;
     },
 
-    ADMIN: process.env.ADMIN_USERNAME,
+    ADMIN: process.env.THORN_ADMIN_USERNAME,
 };
 
 Object.freeze(Agent);

--- a/metadata-fetcher.js
+++ b/metadata-fetcher.js
@@ -26,8 +26,8 @@ var MetadataFetcher = {
         let authToken;
 
         let loginOptions = {
-            username: process.env.ADMIN_USERNAME,
-            password: process.env.ADMIN_PASSWORD,
+            username: process.env.THORN_ADMIN_USERNAME,
+            password: process.env.THORN_ADMIN_PASSWORD,
             version: VERSION,
             xthorn: 'MetadataFetcher',
         };

--- a/metadata-handler.js
+++ b/metadata-handler.js
@@ -153,8 +153,8 @@ var MetadataHandler = {
             return Promise.resolve(this._metadata[module].fields);
         }
 
-        if (process.env.METADATA_FILE) {
-            let fileMetadata = require(process.env.METADATA_FILE);
+        if (process.env.THORN_METADATA_FILE) {
+            let fileMetadata = require(process.env.THORN_METADATA_FILE);
             fileMetadata = this._patchMetadata(fileMetadata);
             
             this._metadata = fileMetadata;

--- a/tests/index.js
+++ b/tests/index.js
@@ -11,7 +11,7 @@ describe('Thorn', () => {
         nock = require('nock');
         thornFile = '../dist/index.js';
 
-        process.env.METADATA_FILE = '../metadata.json';
+        process.env.THORN_METADATA_FILE = '../metadata.json';
 
         nock.disableNetConnect();
         nock.emitter.on('no match', function(req, fullReq, reqData) {
@@ -32,7 +32,7 @@ describe('Thorn', () => {
         _.each(_.keys(require.cache), (key) => {
             delete require.cache[key];
         });
-        delete process.env.METADATA_FILE;
+        delete process.env.THORN_METADATA_FILE;
     });
 
     // The only way to reset the state of Thorn & Thorn.fixtures is to do the below.
@@ -106,7 +106,7 @@ describe('Thorn', () => {
             });
 
             it('should create a fixture', function*() {
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(200, ACCESS)
                     .post(isBulk)
@@ -136,7 +136,7 @@ describe('Thorn', () => {
             it('should create a fixture using options.module', function*() {
                 let fixtureWithoutModule = _.clone(myFixture);
                 delete fixtureWithoutModule[0].module;
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(200, ACCESS)
                     .post(isBulk)
@@ -164,7 +164,7 @@ describe('Thorn', () => {
             });
 
             it('should create a fixture and find it', function*() {
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(200, ACCESS)
                     .post(isBulk)
@@ -194,7 +194,7 @@ describe('Thorn', () => {
             it('should retry fixture creation on 401\'s', function*() {
                 let originalRequestBody;
 
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(200, ACCESS)
                     .post(isBulk, function(requestBody) {
@@ -223,7 +223,7 @@ describe('Thorn', () => {
             });
 
             it('should retry fixture creation until maximum login attempts are reached', function*() {
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(401)
                     .post(isTokenReq)
@@ -261,7 +261,7 @@ describe('Thorn', () => {
                 name: 'TestRecord2',
                 testField1: 'TestField1data2',
             };
-            let server = nock(process.env.API_URL)
+            let server = nock(process.env.THORN_SERVER_URL)
                 .post(isTokenReq)
                 .reply(200, ACCESS)
                 .post(isBulk)
@@ -334,7 +334,7 @@ describe('Thorn', () => {
                 let linkTestId1Regex = /TestId1\/link$/;
 
                 beforeEach(function*() {
-                    nock(process.env.API_URL)
+                    nock(process.env.THORN_SERVER_URL)
                         .post(isTokenReq)
                         .reply(200, ACCESS)
                         .post(isBulk)
@@ -352,7 +352,7 @@ describe('Thorn', () => {
                 });
 
                 it('should link fixtures', function*() {
-                    let server = nock(process.env.API_URL)
+                    let server = nock(process.env.THORN_SERVER_URL)
                         .post(linkTestId1Regex)
                         .reply(200, function(uri, requestBody) {
                             expect(this.req.headers['x-thorn']).to.equal('Fixtures');
@@ -372,7 +372,7 @@ describe('Thorn', () => {
                 it('should retry linking fixtures on 401\'s', function*() {
                     let originalRequestBody;
 
-                    let server = nock(process.env.API_URL)
+                    let server = nock(process.env.THORN_SERVER_URL)
                         .post(linkTestId1Regex, function(requestBody) {
                             originalRequestBody = requestBody;
                             return true;
@@ -399,7 +399,7 @@ describe('Thorn', () => {
 
         describe('cleanup', () => {
             it('should retry clean up until maximum login attempts are reached', function*() {
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
                     .reply(401)
                     .post(isTokenReq)
@@ -437,7 +437,7 @@ describe('Thorn', () => {
                         },
                     };
                     let bigFixture = [record1, record2, record3];
-                    nock(process.env.API_URL)
+                    nock(process.env.THORN_SERVER_URL)
                         .post(isTokenReq)
                         .reply(200, ACCESS)
                         .post(isBulk)
@@ -468,7 +468,7 @@ describe('Thorn', () => {
                 });
 
                 it('should clean up after itself when you call cleanup', function*() {
-                    let server = nock(process.env.API_URL)
+                    let server = nock(process.env.THORN_SERVER_URL)
                         .post(isBulk, function(requestBody) {
                             let requests = requestBody.requests;
 
@@ -498,7 +498,7 @@ describe('Thorn', () => {
                 it('should retry clean up on 401\'s', function*() {
                     let originalRequestBody;
 
-                    let server = nock(process.env.API_URL)
+                    let server = nock(process.env.THORN_SERVER_URL)
                         .post(isBulk, function(requestBody) {
                             originalRequestBody = requestBody;
                             return true;
@@ -527,17 +527,17 @@ describe('Thorn', () => {
 
     describe('Agent', () => {
         beforeEach(() => {
-            nock(process.env.API_URL)
+            nock(process.env.THORN_SERVER_URL)
                 .post(isTokenReq)
                 .reply(200, ACCESS);
         });
 
         describe('as', () => {
             it('should return an Agent with cached username and password', () => {
-                let myAgent = Agent.as(process.env.ADMIN_USERNAME);
+                let myAgent = Agent.as(process.env.THORN_ADMIN_USERNAME);
 
-                expect(myAgent.username).to.equal(process.env.ADMIN_USERNAME);
-                expect(myAgent.password).to.equal(process.env.ADMIN_PASSWORD);
+                expect(myAgent.username).to.equal(process.env.THORN_ADMIN_USERNAME);
+                expect(myAgent.password).to.equal(process.env.THORN_ADMIN_PASSWORD);
             });
         });
 
@@ -545,7 +545,7 @@ describe('Thorn', () => {
             let myAgent;
 
             beforeEach(() => {
-                myAgent = Agent.as(process.env.ADMIN_USERNAME);
+                myAgent = Agent.as(process.env.THORN_ADMIN_USERNAME);
             });
 
             it('should return the original agent if version is unchanged', () => {
@@ -573,11 +573,11 @@ describe('Thorn', () => {
             }
 
             beforeEach(() => {
-                myAgent = Agent.as(process.env.ADMIN_USERNAME);
+                myAgent = Agent.as(process.env.THORN_ADMIN_USERNAME);
             });
 
             it('should send GET request', function*() {
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .get(isNotRealEndpoint)
                     .reply(200, function(uri, requestBody) {
                         expect(this.req.headers['x-thorn']).to.equal('Agent');
@@ -595,7 +595,7 @@ describe('Thorn', () => {
                 let data = {
                     myField: 'myValue',
                 };
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .post(isNotRealEndpoint)
                     .reply(200, function(uri, requestBody) {
                         expect(this.req.headers['x-thorn']).to.equal('Agent');
@@ -615,7 +615,7 @@ describe('Thorn', () => {
                 let data = {
                     myField: 'myUpdatedValue',
                 };
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .put(isNotRealEndpoint)
                     .reply(200, function(uri, requestBody) {
                         expect(this.req.headers['x-thorn']).to.equal('Agent');
@@ -635,7 +635,7 @@ describe('Thorn', () => {
                 let data = {
                     myField: 'myValue',
                 };
-                let server = nock(process.env.API_URL)
+                let server = nock(process.env.THORN_SERVER_URL)
                     .delete(isNotRealEndpoint)
                     .reply(200, function(uri, requestBody) {
                         expect(this.req.headers['x-thorn']).to.equal('Agent');

--- a/tests/metadata-fetcher.js
+++ b/tests/metadata-fetcher.js
@@ -50,7 +50,7 @@ describe('Metadata Fetcher', () => {
 
     describe('metadata retrieval', () => {
         beforeEach(() => {
-            nock(process.env.API_URL)
+            nock(process.env.THORN_SERVER_URL)
                 .post((url) => {
                     return url.indexOf('oauth2/token') >= 0;
                 })
@@ -72,7 +72,7 @@ describe('Metadata Fetcher', () => {
 
     describe('when two fetches are in progress', () => {
         it('should only trigger a single server request', function*() {
-            let server = nock(process.env.API_URL)
+            let server = nock(process.env.THORN_SERVER_URL)
                 .post((url) => {
                     return url.indexOf('oauth2/token') >= 0;
                 })
@@ -92,7 +92,7 @@ describe('Metadata Fetcher', () => {
 
     describe('integration with metadata-helper', () => {
         beforeEach(() => {
-            nock(process.env.API_URL)
+            nock(process.env.THORN_SERVER_URL)
                 .post((url) => {
                     return url.indexOf('oauth2/token') >= 0;
                 })

--- a/tests/metadata-handler.js
+++ b/tests/metadata-handler.js
@@ -212,18 +212,18 @@ describe('Metadata Handler', () => {
 
         describe('when the Users module is defined', () => {
             it('should generate a missing Users.user_hash field definition', function*() {
-                process.env.METADATA_FILE = __dirname + '/fixtures/metadata-handler/users-module-only-without-user-hash.json';
+                process.env.THORN_METADATA_FILE = __dirname + '/fixtures/metadata-handler/users-module-only-without-user-hash.json';
                 let metadata = yield Meta.getRequiredFields('Users');
                 let expected = {
                     name: 'user_hash',
                     type: 'password',
                 };
                 expect(metadata.user_hash).to.eql(expected);
-                delete process.env.METADATA_FILE;
+                delete process.env.THORN_METADATA_FILE;
             });
 
             it('should preserve a pre-existing Users.user_hash field definition', function*() {
-                process.env.METADATA_FILE = __dirname + '/fixtures/metadata-handler/users-module-only-with-user-hash.json';
+                process.env.THORN_METADATA_FILE = __dirname + '/fixtures/metadata-handler/users-module-only-with-user-hash.json';
                 let metadata = yield Meta.getRequiredFields('Users');
                 let expected = {
                     name: 'user_hash',
@@ -232,13 +232,13 @@ describe('Metadata Handler', () => {
                     test: 'abc123',
                 };
                 expect(metadata.user_hash).to.eql(expected);
-                delete process.env.METADATA_FILE;
+                delete process.env.THORN_METADATA_FILE;
             });
         });
 
         describe('when the Users module is not defined', () => {
             it('should not create metadata for a Users module', function*() {
-                process.env.METADATA_FILE = __dirname + '/fixtures/metadata-handler/random-module.json';
+                process.env.THORN_METADATA_FILE = __dirname + '/fixtures/metadata-handler/random-module.json';
                 let errorMsg;
                 try {
                     yield Meta.getRequiredFields('Users');
@@ -246,7 +246,7 @@ describe('Metadata Handler', () => {
                     errorMsg = e.message;
                 }
                 expect(errorMsg).to.eql('Unrecognized module: Users');
-                delete process.env.METADATA_FILE;
+                delete process.env.THORN_METADATA_FILE;
             });
         });
     });

--- a/tests/root.js
+++ b/tests/root.js
@@ -3,9 +3,9 @@
 
 // Set up the test environment.
 before(() => {
-    process.env.ADMIN_USERNAME = 'foo';
-    process.env.ADMIN_PASSWORD = 'bar';
-    process.env.API_URL = 'http://thisisnotarealserver.localdev';
+    process.env.THORN_ADMIN_USERNAME = 'foo';
+    process.env.THORN_ADMIN_PASSWORD = 'bar';
+    process.env.THORN_SERVER_URL = 'http://thisisnotarealserver.localdev';
 
     require('babel-polyfill');
     require('co-mocha');

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -44,7 +44,7 @@ describe('Utils', () => {
                 xthorn: 'TestHeader',
             };
 
-            let server = nock(process.env.API_URL)
+            let server = nock(process.env.THORN_SERVER_URL)
                 .post('/rest/' + options.version + '/oauth2/token')
                 .reply(200, function(uri, requestBody) {
                     expect(requestBody.username).to.equal(options.username);
@@ -86,7 +86,7 @@ describe('Utils', () => {
                 xthorn: 'TestHeader',
             };
 
-            let server = nock(process.env.API_URL)
+            let server = nock(process.env.THORN_SERVER_URL)
                 .post('/rest/' + options.version + '/oauth2/token')
                 .reply(200, function(uri, requestBody) {
                     expect(requestBody.grant_type).to.equal('refresh_token');
@@ -102,9 +102,9 @@ describe('Utils', () => {
     });
 
     describe('constructUrl', () => {
-        it('should return a URL relative to API_URL', () => {
+        it('should return a URL relative to THORN_SERVER_URL', () => {
             let url = utils.constructUrl('location');
-            expect(url.startsWith(process.env.API_URL)).to.be.true;
+            expect(url.startsWith(process.env.THORN_SERVER_URL)).to.be.true;
         });
 
         it('should join arguments in order with slashes', () => {

--- a/utils.js
+++ b/utils.js
@@ -3,9 +3,9 @@
  * @type {string}
  * @private
  */
-const ROOT_URL = process.env.API_URL;
+const ROOT_URL = process.env.THORN_SERVER_URL;
 if (!ROOT_URL) {
-    throw new Error('Please set process.env.API_URL!');
+    throw new Error('Please set process.env.THORN_SERVER_URL!');
 }
 
 let _ = require('lodash');


### PR DESCRIPTION
This is dependent on #87.
At this point in time, this PR Is also based on #88, but it's not a true dependency.
This should be reviewed in tandem with https://github.com/sugarcrm/Mango/pull/33247

We can decide to not move forward with this, but to try to avoid namespace collisions in the environment, I'd like to prepend our variables with "THORN_".

This came from an idea I had, here: 
https://github.com/sugarcrm/thorn/pull/87/files#diff-f51eb776ea13a5f3162bed1bfd0ec458R6