### PR TITLE
Moved co-mocha to the right place in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-preset-es2017": "^6.16.0",
     "babel-polyfill": "^6.20.0",
     "chai": "^3.5.0",
+    "co-mocha": "^1.1.3",
     "commander": "^2.9.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
@@ -25,7 +26,6 @@
     "jsdoc-babel": "^0.2.1",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
-    "co-mocha": "^1.1.3",
     "nock": "^9.0.2",
     "sinon": "^1.17.7"
   },


### PR DESCRIPTION
I'm assuming that `co-` comes before `com` in the "alphabet".