### PR TITLE
Moved the multiple record create test into a describe

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -223,58 +223,60 @@ describe('Thorn', () => {
             });
         });
 
-        it('should create multiple fixtures', function*() {
-            let record1 = {
-                attributes: {
+        describe('creating multiple records', () => {
+            it('should create multiple fixtures', function*() {
+                let record1 = {
+                    attributes: {
+                        name: 'TestRecord1',
+                        testField1: 'TestField1data1',
+                    },
+                };
+                let record2 = {
+                    attributes: {
+                        name: 'TestRecord2',
+                        testField1: 'TestField1data2',
+                    },
+                };
+                let contents1 = {
+                    _module: 'TestModule1',
                     name: 'TestRecord1',
                     testField1: 'TestField1data1',
-                },
-            };
-            let record2 = {
-                attributes: {
+                };
+                let contents2 = {
+                    _module: 'TestModule1',
                     name: 'TestRecord2',
                     testField1: 'TestField1data2',
-                },
-            };
-            let contents1 = {
-                _module: 'TestModule1',
-                name: 'TestRecord1',
-                testField1: 'TestField1data1',
-            };
-            let contents2 = {
-                _module: 'TestModule1',
-                name: 'TestRecord2',
-                testField1: 'TestField1data2',
-            };
-            nock(serverUrl)
-                .post(isTokenReq)
-                .reply(200, ACCESS)
-                .post(isBulk)
-                .reply(200, function(uri, requestBody) {
-                    let requests = requestBody.requests;
-                    let request1 = requests[0];
-                    expect(request1.url).to.contain('/TestModule1');
-                    expect(request1.method).to.equal('POST');
-                    expect(request1.data).to.eql(record1.attributes);
+                };
+                nock(serverUrl)
+                    .post(isTokenReq)
+                    .reply(200, ACCESS)
+                    .post(isBulk)
+                    .reply(200, function(uri, requestBody) {
+                        let requests = requestBody.requests;
+                        let request1 = requests[0];
+                        expect(request1.url).to.contain('/TestModule1');
+                        expect(request1.method).to.equal('POST');
+                        expect(request1.data).to.eql(record1.attributes);
 
-                    let request2 = requests[1];
-                    expect(request2.url).to.contain('/TestModule1');
-                    expect(request2.method).to.equal('POST');
-                    expect(request2.data).to.eql(record2.attributes);
+                        let request2 = requests[1];
+                        expect(request2.url).to.contain('/TestModule1');
+                        expect(request2.method).to.equal('POST');
+                        expect(request2.data).to.eql(record2.attributes);
 
-                    expect(this.req.headers['x-thorn']).to.equal('Fixtures');
+                        expect(this.req.headers['x-thorn']).to.equal('Fixtures');
 
-                    return constructBulkResponse([
-                        contents1,
-                        contents2,
-                    ]);
-                });
-            let myFixture = [record1, record2];
-            let records = yield Fixtures.create(myFixture, {module: 'TestModule1'});
-            let testModuleRecords = records.TestModule1;
-            expect(testModuleRecords.length).to.equal(2);
-            expect(testModuleRecords[0]).to.eql(contents1);
-            expect(testModuleRecords[1]).to.eql(contents2);
+                        return constructBulkResponse([
+                            contents1,
+                            contents2,
+                        ]);
+                    });
+                let myFixture = [record1, record2];
+                let records = yield Fixtures.create(myFixture, {module: 'TestModule1'});
+                let testModuleRecords = records.TestModule1;
+                expect(testModuleRecords.length).to.equal(2);
+                expect(testModuleRecords[0]).to.eql(contents1);
+                expect(testModuleRecords[1]).to.eql(contents2);
+            });
         });
 
         describe('linking', () => {


### PR DESCRIPTION
This is a little nitpick that was bothering me. The 'create multiple fixtures' test sat at a different level from all the other tests. This made it a little incongruous with the other tests.

I recommend looking at this with whitespace turned off.