### PR TITLE
Fix concurrency issue in MetadataHandler::getRequiredFields()

### DIFF
--- a/metadata-handler.js
+++ b/metadata-handler.js
@@ -166,11 +166,16 @@ var MetadataHandler = {
 
         return MetadataFetcher.fetch()
             .then((metadata) => {
-                metadata = this._patchMetadata(metadata);
-                self._metadata = metadata;
+                // If metadata has been cached already it means it has been
+                // patched already too, thus there's no need to re-patch metadata again
+                if (!self._metadata) {
+                    self._metadata = self._patchMetadata(metadata);
+                }
+
                 if (!self._metadata[module]) {
                     throw new Error('Unrecognized module: ' + module);
                 }
+
                 return self._metadata[module].fields;
             });
     },


### PR DESCRIPTION
When you're creating multiple records through `Fixtures.create` you'll eventually execute multiple calls to `MetadataHandler::getRequiredFields()`, which in turn calls MetadataFetcher::fetch() multiple times too and even though we're taking concurrency into account [there](https://github.com/sugarcrm/thorn/blob/master/metadata-fetcher.js#L21) we'll still end up returning a resolved promise which in turn will end up [here](https://github.com/sugarcrm/thorn/pull/110/files#diff-c361a29b24127167098049170dc1c798R169) ending up patching metadata more than once.

You can see this happening when your instance does not have `user_hash` defined as a required field for Users module and you still end up seeing `Users user_hash field is required => true on the Mango side. Skipping metadata patch.` debug message when you're running your tests.