### PR TITLE
.eslintrc.json: Require valid JSDoc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,9 +33,21 @@
         "args": "none"
       }
     ],
-    "comma-dangle": ["error", {
-      "arrays": "always-multiline",
-      "objects": "always-multiline"
-    }]
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline"
+      }
+    ],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireReturn": false,
+        "prefer": {
+          "return": "return"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
This should help ensure our documentation stays nice and clean.