### PR TITLE
editorconfig: Use 2 spaces for YAML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[{*.json,.babelrc}]
+[{*.json,*.yml,.babelrc}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
This is intended for .travis.yml