### PR TITLE
Thorn automagically fills required fields even when their values have been supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ let Fixtures = {
             let request = {
                 url: `/${VERSION}/${model.module}`,
                 method: 'POST',
-                data: model.attributes || {},
+                data: _.cloneDeep(model.attributes) || {},
             };
 
             if (!model.module) {
@@ -331,7 +331,7 @@ let Fixtures = {
             let getRequiredFieldPromise = MetadataHandler.getRequiredFields(model.module)
             .then((requiredFields) => {
                 _.each(requiredFields, (field) => {
-                    if (!request.data[field.name]) {
+                    if (_.isUndefined(request.data[field.name])) {
                         request.data[field.name] = MetadataHandler.generateFieldValue(field);
                     }
                 });

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,24 @@
 {
   "TestModule1": {
-    "fields": []
+    "fields": {
+      "testField3": {
+        "name": "testField3",
+        "type": "bool",
+        "required": true
+      },
+      "testField4": {
+        "name": "testField4",
+        "type": "int",
+        "required": true
+      },
+      "testField5": {
+        "name": "testField5",
+        "type": "varchar",
+        "required": true
+      }
+    }
   },
   "TestModule2": {
-    "fields": []
+    "fields": {}
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -195,7 +195,7 @@ describe('Thorn', () => {
                     .post(isTokenReq)
                     .reply(200, ACCESS)
                     .post(isBulk)
-                    .reply(200, function(uri, requestBody) {
+                    .reply(200, (uri, requestBody) => {
                         let request = requestBody.requests[0];
 
                         expect(request.url).to.contain(cmpFixture.module);
@@ -298,7 +298,7 @@ describe('Thorn', () => {
                         expect(requestBody).to.eql(originalRequestBody);
                         return true;
                     })
-                    .reply(200, function(uri, requestBody) {
+                    .reply(200, (uri, requestBody) => {
                         let request = requestBody.requests[0];
 
                         return constructBulkResponse({

--- a/tests/index.js
+++ b/tests/index.js
@@ -125,16 +125,19 @@ describe('Thorn', () => {
 
                         expect(request.url).to.contain(fixture.module);
                         expect(request.method).to.equal('POST');
-                        expect(request.data).to.eql(fixture.attributes);
+                        expect(request.data).to.contain(fixture.attributes);
 
                         expect(this.req.headers['x-thorn']).to.equal('Fixtures');
 
                         return constructBulkResponse({
                             _module: fixture.module,
                             id: 'TestId1',
-                            name: fixture.attributes.name,
-                            testField1: fixture.attributes.testField1,
-                            testField2: fixture.attributes.testField2,
+                            name: request.data.name,
+                            testField1: request.data.testField1,
+                            testField2: request.data.testField2,
+                            testField3: request.data.testField3,
+                            testField4: request.data.testField4,
+                            testField5: request.data.testField5,
                         });
                     });
                 let createPromise = Fixtures.create(fixture);
@@ -159,16 +162,16 @@ describe('Thorn', () => {
 
                         expect(request.url).to.contain(module);
                         expect(request.method).to.equal('POST');
-                        expect(request.data).to.eql(fixtureWithoutModule.attributes);
+                        expect(request.data).to.contain(fixtureWithoutModule.attributes);
 
                         expect(this.req.headers['x-thorn']).to.equal('Fixtures');
 
                         return constructBulkResponse({
                             _module: module,
                             id: 'TestId1',
-                            name: fixtureWithoutModule.name,
-                            testField1: fixtureWithoutModule.attributes.testField1,
-                            testField2: fixtureWithoutModule.attributes.testField2,
+                            name: request.data.name,
+                            testField1: request.data.testField1,
+                            testField2: request.data.testField2,
                         });
                     });
                 let createPromise = Fixtures.create(fixtureWithoutModule, { module });
@@ -176,6 +179,48 @@ describe('Thorn', () => {
                 expect(isPromise(createPromise)).to.be.true;
 
                 yield createPromise;
+                expect(server.isDone()).to.be.true;
+            });
+
+            it('should only fill required fields when respective values aren\'t supplied', function*() {
+                let falsyFixture = _.cloneDeep(fixture);
+                falsyFixture.attributes.testField3 = false;
+                falsyFixture.attributes.testField4 = 0;
+
+                // Cloning falsyFixture so that we can use it in the expectations below to make sure that after calling
+                // Fixtures.create, the original values are still the same as initially defined.
+                let cmpFixture = _.cloneDeep(falsyFixture);
+
+                let server = nock(process.env.THORN_SERVER_URL)
+                    .post(isTokenReq)
+                    .reply(200, ACCESS)
+                    .post(isBulk)
+                    .reply(200, function(uri, requestBody) {
+                        let request = requestBody.requests[0];
+
+                        expect(request.url).to.contain(cmpFixture.module);
+                        expect(request.method).to.equal('POST');
+
+                        expect(request.data.name).to.equal(cmpFixture.attributes.name);
+                        expect(request.data.testField1).to.equal(cmpFixture.attributes.testField1);
+                        expect(request.data.testField2).to.equal(cmpFixture.attributes.testField2);
+                        expect(request.data.testField3).to.equal(cmpFixture.attributes.testField3);
+                        expect(request.data.testField4).to.equal(cmpFixture.attributes.testField4);
+                        expect(request.data.testField5).to.not.be.undefined;
+
+                        return constructBulkResponse({
+                            _module: cmpFixture.module,
+                            id: 'TestId1',
+                            name: request.data.name,
+                            testField1: request.data.testField1,
+                            testField2: request.data.testField2,
+                            testField3: request.data.testField3,
+                            testField4: request.data.testField4,
+                            testField5: request.data.testField5,
+                        });
+                    });
+
+                yield Fixtures.create(falsyFixture);
                 expect(server.isDone()).to.be.true;
             });
 
@@ -193,16 +238,6 @@ describe('Thorn', () => {
                         testField1: 'TestField1data2',
                     },
                 };
-                let contents1 = {
-                    _module: module,
-                    name: fixture1.attributes.name,
-                    testField1: fixture1.attributes.testField1,
-                };
-                let contents2 = {
-                    _module: module,
-                    name: fixture2.attributes.name,
-                    testField1: fixture2.attributes.testField1,
-                };
 
                 let server = nock(process.env.THORN_SERVER_URL)
                     .post(isTokenReq)
@@ -214,24 +249,35 @@ describe('Thorn', () => {
                         let request1 = requests[0];
                         expect(request1.url).to.contain(module);
                         expect(request1.method).to.equal('POST');
-                        expect(request1.data).to.eql(fixture1.attributes);
+                        expect(request1.data).to.contain(fixture1.attributes);
 
                         let request2 = requests[1];
                         expect(request2.url).to.contain(module);
                         expect(request2.method).to.equal('POST');
-                        expect(request2.data).to.eql(fixture2.attributes);
+                        expect(request2.data).to.contain(fixture2.attributes);
 
                         expect(this.req.headers['x-thorn']).to.equal('Fixtures');
 
-                        return constructBulkResponse([
-                            contents1,
-                            contents2,
-                        ]);
+                        return constructBulkResponse([{
+                            _module: module,
+                            name: request1.data.name,
+                            testField1: request1.data.testField1,
+                            testField2: request1.data.testField2,
+                            testField3: request1.data.testField3,
+                            testField4: request1.data.testField4,
+                            testField5: request1.data.testField5,
+                        }, {
+                            _module: module,
+                            name: request2.data.name,
+                            testField1: request2.data.testField1,
+                            testField2: request2.data.testField2,
+                            testField3: request2.data.testField3,
+                            testField4: request2.data.testField4,
+                            testField5: request2.data.testField5,
+                        }]);
                     });
 
-                let records = yield Fixtures.create([fixture1, fixture2], { module });
-                let testModuleRecords = records[module];
-                expect(testModuleRecords).to.eql([contents1, contents2]);
+                yield Fixtures.create([fixture1, fixture2], { module });
                 expect(server.isDone()).to.be.true;
             });
 
@@ -252,13 +298,20 @@ describe('Thorn', () => {
                         expect(requestBody).to.eql(originalRequestBody);
                         return true;
                     })
-                    .reply(200, constructBulkResponse({
-                        _module: fixture.module,
-                        id: 'TestId1',
-                        name: fixture.attributes.name,
-                        testField1: fixture.attributes.testField1,
-                        testField2: fixture.attributes.testField2,
-                    }));
+                    .reply(200, function(uri, requestBody) {
+                        let request = requestBody.requests[0];
+
+                        return constructBulkResponse({
+                            _module: fixture.module,
+                            id: 'TestId1',
+                            name: request.data.name,
+                            testField1: request.data.testField1,
+                            testField2: request.data.testField2,
+                            testField3: request.data.testField3,
+                            testField4: request.data.testField4,
+                            testField5: request.data.testField5,
+                        });
+                    });
 
                 yield Fixtures.create(fixture);
                 expect(server.isDone()).to.be.true;


### PR DESCRIPTION
While creating fixtures, if one supplies a falsy (from a JS perspective) value to a required field, Thorn automagically fills those fields as if no values have been supplied.

E.g.: 
```
Module: Opportunities
Field: amount
Value: 0.0
```
E.g.: 
```javascript
var x = 0.0;
console.log(!x ? 'foo' : 'bar'); // foo is printed
```
The bug seems to be [here](https://github.com/sugarcrm/thorn/blob/master/index.js#L336).