### PR TITLE
Nock 9.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jsdoc-babel": "^0.2.1",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
-    "nock": "^9.0.4",
+    "nock": "^9.0.7",
     "sinon": "^1.17.7"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,9 +2512,9 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nock@^9.0.4:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.6.tgz#4ab39dcae285360d117109442b1c34663303ff33"
+nock@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.7.tgz#cc93481bb15f38bec2a39c4442be07825235b1a1"
   dependencies:
     chai ">=1.9.2 <4.0.0"
     debug "^2.2.0"


### PR DESCRIPTION
Closes #128 (decided to skip 9.0.6)