### PR TITLE
metadata-handler: Handle single-number precisions

### DIFF
--- a/metadata-handler.js
+++ b/metadata-handler.js
@@ -49,12 +49,11 @@ let MetadataHandler = {
                 afterDecimal = afterDecimal > 2 ? 2 : afterDecimal;
 
                 // To avoid JS floating point issues, build string and cast as float
-                val = Number.parseFloat(
-                    `${faker.random.number({max: Math.pow(10, beforeDecimal)})
-                     }.${
-                    faker.random.number({max: Math.pow(10, afterDecimal)})}`
-                );
-
+                val = `${faker.random.number({max: Math.pow(10, beforeDecimal)})}`;
+                if (afterDecimal > 0) {
+                    val += `.${faker.random.number({max: Math.pow(10, afterDecimal)})}`;
+                }
+                val = Number.parseFloat(val);
                 break;
             }
             case 'date':
@@ -142,14 +141,10 @@ let MetadataHandler = {
      */
     _parsePrecision(prec) {
         let [precision, scale] = prec.split(',');
-        if (scale) {
-            let afterDecimal = Number.parseInt(scale, 10);
-            let beforeDecimal = Number.parseInt(precision, 10) - afterDecimal;
-            return [beforeDecimal, afterDecimal];
-        }
-
-        // FIXME!!!
-        throw new Error('Single-digit precision specifications are not currently supported!');
+        scale = scale || 0;
+        let afterDecimal = Number.parseInt(scale, 10);
+        let beforeDecimal = Number.parseInt(precision, 10) - afterDecimal;
+        return [beforeDecimal, afterDecimal];
     },
 
     /**

--- a/tests/metadata-handler.js
+++ b/tests/metadata-handler.js
@@ -136,6 +136,12 @@ describe('Metadata Handler', () => {
                 expect(intPart.length).to.be.at.most(3);
                 expect(decimalPart.length).to.be.at.most(2);
             });
+
+            it('should default to no digits after the decimal', () => {
+                let value = Meta.generateFieldValue({type: 'decimal', len: '3'});
+                expect(value).to.be.a.number;
+                expect(Number.isInteger(value)).to.be.true;
+            });
         });
 
         describe('datetimes', () => {


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/ms187746.aspx says that
the default scale is 0; i.e. that there should be no digits after the
decimal point.