### PR TITLE
Update jsdoc-babel to 0.3.0

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -7,6 +7,7 @@
     "node_modules/jsdoc-babel"
   ],
   "babel": {
-    "plugins": ["transform-class-properties"]
+    "plugins": ["transform-class-properties"],
+    "babelrc": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-spawn-mocha": "^3.1.0",
     "gulp-watch": "^4.3.11",
     "istanbul": "^0.4.5",
-    "jsdoc-babel": "^0.2.1",
+    "jsdoc-babel": "^0.3.0",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
     "nock": "^9.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,11 +618,11 @@ babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.15.0:
+babylon@^6.11.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
-babylon@^6.16.1:
+babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
@@ -2101,9 +2101,9 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdoc-babel@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/jsdoc-babel/-/jsdoc-babel-0.2.1.tgz#427fcd775f7abf099806ab66aa382b496eea1bd0"
+jsdoc-babel@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-babel/-/jsdoc-babel-0.3.0.tgz#2eaaefd9eca8d8b78845394a1cce9d8896befbe1"
   dependencies:
     lodash "^4.13.1"
 


### PR DESCRIPTION
I've been trying to do this for ages; finally it works!

The key was to disable .babelrc parsing in jsdoc.json.

No changes to documentation except updated timestamps.