### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ jspm_packages
 
 # Yarn Integrity file
 .yarn-integrity
+
+# npm lockfile. We're using yarn, so just ignore this file
+package-lock.json


### PR DESCRIPTION
Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>

We're using yarn, so IMO it makes sense to ignore this so we're not maintaining two different files.