### PR TITLE
gulpfile: Do not babelify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task('doc', (cb) => {
 
 gulp.task('lint', () => {
     const eslint = require('gulp-eslint');
-    return gulp.src(_.union(sourceFiles, ['tests/**/*.js', 'gulpfile.babel.js']))
+    return gulp.src(_.union(sourceFiles, ['tests/**/*.js', 'gulpfile.js']))
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError());


### PR DESCRIPTION
We don't use any features in the Gulpfile that require it,
so don't bother Babelifying it. This is a small step towards
getting rid of Babel for Thorn.

Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>