### PR TITLE
Only support node 6.10.3 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prepublish": "gulp"
   },
   "engines": {
-    "node": ">=6.0.0",
+    "node": ">=6.10.3",
     "npm": ">=3.0.0"
   },
   "keywords": [


### PR DESCRIPTION
6.x is LTS and there are some differences between 6.x versions.
So we should state upfront that we don't support older 6.x versions
or else we're setting ourselves up for potential compatibility troubles.

Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>