### PR TITLE
Change prepublish script to prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "doc": "gulp doc",
     "test": "gulp test",
     "lint": "gulp lint",
-    "prepublish": "gulp"
+    "prepare": "gulp"
   },
   "engines": {
     "node": ">=6.10.3",


### PR DESCRIPTION
They do exactly the same thing, but prepublish is
deprecated because it has a confusing name.

Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>