### PR TITLE
Invalidate admin tokens between Fixtures and Agent.ADMIN

### DIFF
--- a/index.js
+++ b/index.js
@@ -639,6 +639,7 @@ class UserAgent {
         }).then((response) => {
             this._updateAuthState(response);
             this._setState('sessionAttempt', 0);
+
         }).catch(() => {
             this._setState('loginPromise', null);
             return this._login();
@@ -690,6 +691,10 @@ class UserAgent {
         headers['OAuth-Token'] = response.body.access_token;
         this._setState('headers', headers);
         this._setState('refreshToken', response.body.refresh_token);
+
+        if (this.username === Agent.ADMIN) {
+            Fixtures._storeAuth(response);
+        }
     };
 
     /**

--- a/tests/index.js
+++ b/tests/index.js
@@ -829,6 +829,41 @@ describe('Thorn', () => {
                 yield Agent.as('TestUsername').get('not/real/endpoint');
                 expect(server.isDone()).to.be.true;
             });
+
+            it('should reset Fixtures tokens when using the Admin', function*() {
+                let server = nock(process.env.THORN_SERVER_URL)
+                    .post(isTokenReq)
+                    .reply(200, ACCESS)
+                    .post(isBulk)
+                    .reply(200, (uri, requestBody) => {
+                        return constructBulkResponse({
+                            _module: 'TestModule1',
+                            name: 'DummyRecord1',
+                        })
+                    })
+                    .post(isTokenReq)
+                    .reply(200, {
+                        access_token: 'New-Access-Token',
+                        refresh_token: 'New-Refresh-Token',
+                    })
+                    .get(/not\/real\/endpoint/)
+                    .reply(200);
+
+                yield Fixtures.create({
+                    attributes: {name: 'DummyRecord1'},
+                    module: 'TestModule1',
+                }); // force Fixtures login
+
+                expect(Fixtures._headers['OAuth-Token']).to.equal('Test-Access-Token');
+                expect(Fixtures._refreshToken).to.equal('Test-Refresh-Token');
+
+                yield Agent.as(Agent.ADMIN).get('not/real/endpoint');
+
+                expect(Fixtures._headers['OAuth-Token']).to.equal('New-Access-Token');
+                expect(Fixtures._refreshToken).to.equal('New-Refresh-Token');
+
+                expect(server.isDone()).to.be.true;
+            });
         });
 
         describe('on', () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -219,7 +219,12 @@ describe('Utils', () => {
                 afterRefresh: sandbox.stub(),
             };
 
-            sandbox.stub(utils, 'refresh').returns(Promise.resolve({body: {access_token: 'Token-2'}}));
+            sandbox.stub(utils, 'refresh').returns(Promise.resolve({
+                body: {access_token: 'Token-2'},
+                response: {
+                    statusCode: 200,
+                },
+            }));
 
             let expectedRefreshOptions = {
                 version: wrappedOptions.retryVersion,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -242,4 +242,23 @@ describe('Utils', () => {
             expect(response).to.eql(wrappedResponses[1]);
         });
     });
+
+    describe('isSuccessfulResponse', () => {
+        it('should throw on non-numeric inputs', () => {
+            let status = 'Not a number';
+            expect(() => utils.isSuccessfulResponse(status)).to.throw(`Invalid status code received: ${status}`);
+        });
+
+        it('should throw on inputs outside the range of HTTP response codes', () => {
+            expect(() => utils.isSuccessfulResponse(50)).to.throw('Invalid status code received: 50');
+            expect(() => utils.isSuccessfulResponse(623)).to.throw('Invalid status code received: 623');
+        });
+
+        it('should correctly classify HTTP response codes', () => {
+            expect(utils.isSuccessfulResponse(200)).to.be.true;
+            expect(utils.isSuccessfulResponse(304)).to.be.true;
+            expect(utils.isSuccessfulResponse(401)).to.be.false;
+            expect(utils.isSuccessfulResponse(500)).to.be.false;
+        });
+    });
 });

--- a/utils.js
+++ b/utils.js
@@ -147,6 +147,10 @@ let utils = {
                 token: options.refreshToken,
                 xthorn: options.xthorn,
             }).then((response) => {
+                if (!utils.isSuccessfulResponse(response.response.statusCode)) {
+                    throw new Error(`Unsuccessful refresh! Status code is ${response.response.statusCode}`);
+                }
+
                 options.afterRefresh(response);
 
                 // FIXME Currently, we have to update the HTTP parameters after the refresh

--- a/utils.js
+++ b/utils.js
@@ -36,6 +36,21 @@ let utils = {
     },
 
     /**
+     * Determine if the given HTTP status code represents success.
+     *
+     * @param {number} statusCode HTTP status code.
+     * @return {boolean} `true` if the status code represents a successful
+     *   request; `false` otherwise.
+     */
+    isSuccessfulResponse: function successfulResponse(statusCode) {
+        if (!Number.isInteger(statusCode) || statusCode < 100 || statusCode >= 600) {
+            throw new Error(`Invalid status code received: ${statusCode}`);
+        }
+
+        return statusCode < 400;
+    },
+
+    /**
      * Construct a URL relative to the base URL.
      * Each argument is joined with a `/`.
      *

--- a/utils.js
+++ b/utils.js
@@ -134,7 +134,7 @@ let utils = {
         return chakramMethod.apply(chakram, args).then((response) => {
             utils.assertSaneResponse(response);
 
-            if (response.response.statusCode === 200) {
+            if (utils.isSuccessfulResponse(response.response.statusCode)) {
                 return response;
             }
 


### PR DESCRIPTION
If the same user logs in twice, the second login will invalidate the refresh token from the first login.

Therefore, after `Fixtures` logs in or refreshes the admin, overwrite the access and refresh tokens for `Agent.ADMIN` (and vice-versa).

Possibly related to #145, but not 100% sure that it's the same issue.

Blocked by #139 since I want to use a method I've introduced there.

Also note: **this is a breaking change**, see 06779f7.