### PR TITLE
Ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ jspm_packages
 
 # npm lockfile. We're using yarn, so just ignore this file
 package-lock.json
+
+# PHPStorm configuration
+.idea


### PR DESCRIPTION
Most Thorn maintainers use PHPStorm, so ignore it so it doesn't show up when doing `npm publish`.