### PR TITLE
Only support Node 6.12.3+ and npm 5.6.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "prepare": "gulp"
   },
   "engines": {
-    "node": ">=6.10.3",
-    "npm": ">=3.0.0"
+    "node": ">=6.12.3",
+    "npm": ">=5.6.0"
   },
   "keywords": [
     "sugarcrm"


### PR DESCRIPTION
Signed-off-by: Bob Wombat Hogg <rhogg@sugarcrm.com>

These were chosen by virtue of what's currently used by Homebrew's `node@6` formula.

Whether we decide to move to Node 8 or later further down the road is a different discussion.